### PR TITLE
Update README.md

### DIFF
--- a/mythos-testnet/README.md
+++ b/mythos-testnet/README.md
@@ -41,7 +41,7 @@ rm -rf /root/mythos
 ```
 
 ```shell=
-mkdir mythos && cd mythos && wget "https://github.com/loredanacirstea/tempreleases/raw/main/mythos-testnet/linux_x86_64.zip?commit=b0cc7196927a57d31cc8fc6fc864fc8f3c85d920" -O linux_x86_64.zip && unzip linux_x86_64.zip && mv linux_x86_64 ./bin && cd bin && chmod +x ./mythosd && cd ..
+mkdir mythos && cd mythos && wget "https://github.com/loredanacirstea/tempreleases/raw/main/mythos-testnet/linux_x86_64.zip?commit=0e4109955ec06886a058765f6cf2a260d1218b59" -O linux_x86_64.zip && unzip linux_x86_64.zip && mv linux_x86_64 ./bin && cd bin && chmod +x ./mythosd && cd ..
 ```
 
 Set up the path for the mythosd executable. E.g.


### PR DESCRIPTION
commit hash fixed in binaries download link to point to testnet 15 version.